### PR TITLE
remove extra indirection that is not currently used

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -6,13 +6,13 @@ package akka.http.javadsl
 
 import java.util.{ Optional, Collection => JCollection }
 
-import akka.annotation.DoNotInherit
+import akka.annotation.{ ApiMayChange, DoNotInherit }
 import akka.http.scaladsl
 import akka.japi.Util
 import akka.stream.TLSClientAuth
 import com.github.ghik.silencer.silent
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
-import javax.net.ssl.{ SSLContext, SSLParameters }
+import javax.net.ssl.{ SSLContext, SSLEngine, SSLParameters }
 
 import scala.compat.java8.OptionConverters
 
@@ -22,10 +22,27 @@ object ConnectionContext {
     //#https-context-creation
     scaladsl.ConnectionContext.httpsClient(sslContext)
 
+  /**
+   *  If you want complete control over how to create the SSLEngine you can use this method.
+   *
+   *  Note that this means it is up to you to make sure features like SNI and hostname verification
+   *  are enabled as needed.
+   */
+  @ApiMayChange
+  def httpsClient(createEngine: akka.japi.function.Function2[String, Int, SSLEngine]): HttpsConnectionContext =
+    scaladsl.ConnectionContext.httpsClient((host, port) => createEngine(host, port))
+
   //#https-context-creation
   def httpsServer(sslContext: SSLContext): HttpsConnectionContext = // ...
     //#https-context-creation
     scaladsl.ConnectionContext.httpsServer(sslContext)
+
+  /**
+   *  If you want complete control over how to create the SSLEngine you can use this method.
+   */
+  @ApiMayChange
+  def httpsServer(createEngine: akka.japi.function.Creator[SSLEngine]): HttpsConnectionContext =
+    scaladsl.ConnectionContext.httpsServer(() => createEngine.create())
 
   // ConnectionContext
   /** Used to serve HTTPS traffic. */

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -45,11 +45,9 @@ object ConnectionContext {
   @ApiMayChange
   def httpsServer(createSSLEngine: () => SSLEngine): HttpsConnectionContext =
     new HttpsConnectionContext(Right({
-      case None =>
-        Engine(createSSLEngine)
-      case Some(_) =>
-        throw new IllegalArgumentException("host and port supplied for connection based on server connection context")
-    }: Option[(String, Int)] => Engine))
+      case None    => createSSLEngine()
+      case Some(_) => throw new IllegalArgumentException("host and port supplied for connection based on server connection context")
+    }: Option[(String, Int)] => SSLEngine))
 
   //#https-context-creation
   /**
@@ -57,7 +55,7 @@ object ConnectionContext {
    */
   def httpsClient(context: SSLContext): HttpsConnectionContext = // ...
     //#https-context-creation
-    httpsClient((host, port) => () => {
+    httpsClient((host, port) => {
       val engine = context.createSSLEngine(host, port)
       engine.setUseClientMode(true)
 
@@ -77,13 +75,11 @@ object ConnectionContext {
    *  are enabled as needed.
    */
   @ApiMayChange
-  def httpsClient(createSSLEngine: (String, Int) => () => SSLEngine): HttpsConnectionContext = // ...
+  def httpsClient(createSSLEngine: (String, Int) => SSLEngine): HttpsConnectionContext = // ...
     new HttpsConnectionContext(Right({
-      case None =>
-        throw new IllegalArgumentException("host and port missing for connection based on client connection context")
-      case Some((host, port)) =>
-        Engine(createSSLEngine(host, port))
-    }: Option[(String, Int)] => Engine))
+      case None               => throw new IllegalArgumentException("host and port missing for connection based on client connection context")
+      case Some((host, port)) => createSSLEngine(host, port)
+    }: Option[(String, Int)] => SSLEngine))
 
   @deprecated("use httpsClient, httpsServer, or the lower-level SSLEngine-based constructor", "10.2.0")
   def https(
@@ -97,8 +93,6 @@ object ConnectionContext {
 
   def noEncryption() = HttpConnectionContext
 }
-
-private[http] case class Engine(create: () => SSLEngine, validate: SSLSession => Try[Unit] = _ => Success(()))
 
 @deprecated("here to be able to keep supporting the old API", since = "10.2.0")
 private[http] case class DeprecatedSslContextParameters(
@@ -119,7 +113,7 @@ private[http] case class DeprecatedSslContextParameters(
  */
 @InternalApi
 @silent("since 10.2.0")
-final class HttpsConnectionContext private[http] (private[http] val sslContextData: Either[DeprecatedSslContextParameters, Option[(String, Int)] => Engine])
+final class HttpsConnectionContext private[http] (private[http] val sslContextData: Either[DeprecatedSslContextParameters, Option[(String, Int)] => SSLEngine])
   extends akka.http.javadsl.HttpsConnectionContext with ConnectionContext {
   protected[http] override final def defaultPort: Int = 443
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -16,7 +16,6 @@ import javax.net.ssl._
 import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.compat.java8.OptionConverters._
-import scala.util.{ Success, Try }
 
 trait ConnectionContext extends akka.http.javadsl.ConnectionContext {
   @deprecated("Internal method, left for binary compatibility", since = "10.2.0")
@@ -37,10 +36,7 @@ object ConnectionContext {
     })
 
   /**
-   *  If you want complete control over how to create the SSLEngine you can use this method:
-   *
-   *  Note that this means it is up to you to make sure features like SNI and Hostname Verification
-   *  are enabled as needed.
+   *  If you want complete control over how to create the SSLEngine you can use this method.
    */
   @ApiMayChange
   def httpsServer(createSSLEngine: () => SSLEngine): HttpsConnectionContext =
@@ -69,9 +65,9 @@ object ConnectionContext {
     })
 
   /**
-   *  If you want complete control over how to create the SSLEngine you can use this method:
+   *  If you want complete control over how to create the SSLEngine you can use this method.
    *
-   *  Note that this means it is up to you to make sure features like SNI and Hostname Verification
+   *  Note that this means it is up to you to make sure features like SNI and hostname verification
    *  are enabled as needed.
    */
   @ApiMayChange

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -796,8 +796,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
           case Left(ssl) =>
             TLS(ssl.sslContext, ssl.sslConfig, ssl.firstSession, role, hostInfo = hostInfo, closing = TLSClosing.eagerClose)
           case Right(engineCreator) =>
-            val engine = engineCreator(hostInfo)
-            TLS(engine.create, engine.validate, TLSClosing.eagerClose)
+            TLS(() => engineCreator(hostInfo), TLSClosing.eagerClose)
         }
       case other =>
         TLSPlacebo() // if it's not HTTPS, we don't enable SSL/TLS

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
@@ -14,7 +14,7 @@ import akka.http.impl.util._
 import akka.http.scaladsl.{ ConnectionContext, Http }
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
 import akka.http.scaladsl.model.headers.{ Host, `Tls-Session-Info` }
-import javax.net.ssl.{ SSLContext, TrustManagerFactory }
+import javax.net.ssl.{ SSLContext, SSLEngine, TrustManagerFactory }
 import org.scalatest.time.{ Seconds, Span }
 
 import scala.concurrent.Future
@@ -69,12 +69,12 @@ class TlsEndpointVerificationSpec extends AkkaSpecWithMaterializer("""
         context.init(null, certManagerFactory.getTrustManagers, new SecureRandom)
         context
       }
-      val insecureSslEngineFactory = () => {
-        val engine = context.createSSLEngine()
+      def createInsecureSslEngine(host: String, port: Int): SSLEngine = {
+        val engine = context.createSSLEngine(host, port)
         engine.setUseClientMode(true)
         engine
       }
-      val clientConnectionContext = ConnectionContext.httpsClient((host, port) => insecureSslEngineFactory)
+      val clientConnectionContext = ConnectionContext.httpsClient(createInsecureSslEngine _)
 
       // We try to connect to 'hijack.de', and even though this connection is hijacked by a suspicious server
       // identifying as akka.example.org we want to connect anyway

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -170,7 +170,7 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
           val e = ssl.sslContext.createSSLEngine()
           TlsUtils.applySessionParameters(e, ssl.firstSession)
           e
-        case Right(e) => e(None).create()
+        case Right(e) => e(None)
       }
       eng = Some(engine)
       engine.setUseClientMode(false)
@@ -195,7 +195,7 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
           val e = ssl.sslContext.createSSLEngine(host, port)
           TlsUtils.applySessionParameters(e, ssl.firstSession)
           e
-        case Right(e) => e(Some((host, port))).create()
+        case Right(e) => e(Some((host, port)))
       }
       engine.setUseClientMode(true)
       Http2AlpnSupport.clientSetApplicationProtocols(engine, Array("h2"))

--- a/docs/src/main/paradox/compatibility-guidelines.md
+++ b/docs/src/main/paradox/compatibility-guidelines.md
@@ -86,6 +86,8 @@ Scala
 Java
 :   ```java
     akka.http.javadsl.ClientTransport
+    akka.http.javadsl.ConnectionContext#httpsClient
+    akka.http.javadsl.ConnectionContext#httpsServer
     akka.http.javadsl.settings.ClientConnectionSettings#getTransport
     akka.http.javadsl.settings.ClientConnectionSettings#withTransport
     akka.http.javadsl.settings.ConnectionPoolSettings#appendHostOverride


### PR DESCRIPTION
Basically that only removes the validation part that currently couldn't be customized. I guess it makes sense to add that part of the API back later but maybe for now it's not needed.