### PR TITLE
simplify types

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -29,13 +29,14 @@ import scala.collection.immutable
 /**
  * Represents one direction of an Http2 substream.
  */
-private[http2] sealed trait Http2SubStream[+T] {
+private[http2] sealed trait Http2SubStream {
+  type T
   val initialHeaders: ParsedHeadersFrame
   val data: Source[T, Any]
   val correlationAttributes: Map[AttributeKey[_], _]
   def streamId: Int = initialHeaders.streamId
 
-  def withCorrelationAttributes(attributes: Map[AttributeKey[_], _]): Http2SubStream[T]
+  def withCorrelationAttributes(attributes: Map[AttributeKey[_], _]): Http2SubStream
 
   def createRequestEntity(contentLength: Long, contentType: ContentType): RequestEntity =
     this match {
@@ -46,23 +47,35 @@ private[http2] sealed trait Http2SubStream[+T] {
       /* contentLength undefined */
       case c: ChunkedHttp2SubStream => HttpEntity.Chunked(contentType, c.data)
     }
+
+  def createResponseEntity(contentLength: Long, contentType: ContentType): RequestEntity
 }
 
 private[http2] final case class ByteHttp2SubStream(
   initialHeaders:        ParsedHeadersFrame,
   data:                  Source[ByteString, Any],
   correlationAttributes: Map[AttributeKey[_], _] = Map.empty
-) extends Http2SubStream[ByteString] {
-  override def withCorrelationAttributes(attributes: Map[AttributeKey[_], _]): Http2SubStream[ByteString] =
+) extends Http2SubStream {
+  type T = ByteString
+  override def withCorrelationAttributes(attributes: Map[AttributeKey[_], _]): Http2SubStream =
     copy(correlationAttributes = attributes)
+
+  def createResponseEntity(contentLength: Long, contentType: ContentType): RequestEntity = {
+    // Ignore trailing headers when content-length is defined
+    if (contentLength == 0) HttpEntity.Empty
+    else if (contentLength > 0) HttpEntity.Default(contentType, contentLength, data)
+    else HttpEntity.Chunked.fromData(contentType, data)
+  }
 }
 
 private[http2] final case class ChunkedHttp2SubStream(
   initialHeaders:        ParsedHeadersFrame,
   data:                  Source[HttpEntity.ChunkStreamPart, Any],
   correlationAttributes: Map[AttributeKey[_], _]                 = Map.empty
-) extends Http2SubStream[HttpEntity.ChunkStreamPart] {
-  override def withCorrelationAttributes(attributes: Map[AttributeKey[_], _]): Http2SubStream[HttpEntity.ChunkStreamPart] =
+) extends Http2SubStream {
+  type T = HttpEntity.ChunkStreamPart
+
+  override def withCorrelationAttributes(attributes: Map[AttributeKey[_], _]): Http2SubStream =
     copy(correlationAttributes = attributes)
 
   def createResponseEntity(contentLength: Long, contentType: ContentType): RequestEntity = {
@@ -110,13 +123,13 @@ private[http] object Http2Blueprint {
       idleTimeoutIfConfigured(settings.idleTimeout)
   }
 
-  def httpLayerClient(masterHttpHeaderParser: HttpHeaderParser, log: LoggingAdapter): BidiFlow[HttpRequest, Http2SubStream[Any], ChunkedHttp2SubStream, HttpResponse, NotUsed] = {
+  def httpLayerClient(masterHttpHeaderParser: HttpHeaderParser, log: LoggingAdapter): BidiFlow[HttpRequest, Http2SubStream, Http2SubStream, HttpResponse, NotUsed] = {
     BidiFlow.fromFlows(
       Flow[HttpRequest].statefulMapConcat { () =>
         val renderer = RequestRendering.createRenderer(log)
         request => renderer(request) :: Nil
       },
-      Flow[ChunkedHttp2SubStream].statefulMapConcat { () =>
+      Flow[Http2SubStream].statefulMapConcat { () =>
         val headerParser = masterHttpHeaderParser.createShallowCopy()
         stream => ResponseParsing.parseResponse(headerParser)(stream) :: Nil
       }
@@ -157,14 +170,14 @@ private[http] object Http2Blueprint {
    * Creates substreams for every stream and manages stream state machines
    * and handles priorization (TODO: later)
    */
-  def serverDemux(settings: Http2CommonSettings, initialDemuxerSettings: immutable.Seq[Setting], upgraded: Boolean): BidiFlow[Http2SubStream[Any], FrameEvent, FrameEvent, Http2SubStream[ByteString], NotUsed] =
+  def serverDemux(settings: Http2CommonSettings, initialDemuxerSettings: immutable.Seq[Setting], upgraded: Boolean): BidiFlow[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream, NotUsed] =
     BidiFlow.fromGraph(new Http2ServerDemux(settings, initialDemuxerSettings, upgraded))
 
   /**
    * Creates substreams for every stream and manages stream state machines
    * and handles priorization (TODO: later)
    */
-  def clientDemux(settings: Http2CommonSettings, masterHttpHeaderParser: HttpHeaderParser): BidiFlow[Http2SubStream[Any], FrameEvent, FrameEvent, ChunkedHttp2SubStream, NotUsed] =
+  def clientDemux(settings: Http2CommonSettings, masterHttpHeaderParser: HttpHeaderParser): BidiFlow[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream, NotUsed] =
     BidiFlow.fromGraph(new Http2ClientDemux(settings, masterHttpHeaderParser))
 
   /**
@@ -175,7 +188,7 @@ private[http] object Http2Blueprint {
    * that must be reproduced in an HttpResponse. This can be done automatically for the `bind`` API but for
    * `bindFlow` the user needs to take of this manually.
    */
-  def httpLayer(settings: ServerSettings, log: LoggingAdapter): BidiFlow[HttpResponse, Http2SubStream[Any], Http2SubStream[ByteString], HttpRequest, NotUsed] = {
+  def httpLayer(settings: ServerSettings, log: LoggingAdapter): BidiFlow[HttpResponse, Http2SubStream, Http2SubStream, HttpRequest, NotUsed] = {
     val parserSettings = settings.parserSettings
     // This is master header parser, every other usage should do .createShallowCopy()
     // HttpHeaderParser is not thread safe and should not be called concurrently,
@@ -183,7 +196,7 @@ private[http] object Http2Blueprint {
     val masterHttpHeaderParser = HttpHeaderParser(parserSettings, log)
     BidiFlow.fromFlows(
       Flow[HttpResponse].map(ResponseRendering.renderResponse(settings, log)),
-      Flow[Http2SubStream[ByteString]].via(StreamUtils.statefulAttrsMap { attrs =>
+      Flow[Http2SubStream].via(StreamUtils.statefulAttrsMap { attrs =>
         val headerParser = masterHttpHeaderParser.createShallowCopy()
         RequestParsing.parseRequest(headerParser, settings, attrs)
       }))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -28,7 +28,9 @@ import scala.util.control.NoStackTrace
  * Mixed into the Http2ServerDemux graph logic.
  */
 @InternalApi
-private[http2] trait Http2StreamHandling[T] { self: GraphStageLogic with LogHelper =>
+private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper =>
+  type T
+
   // required API from demux
   def isServer: Boolean
   def multiplexer: Http2Multiplexer
@@ -100,7 +102,7 @@ private[http2] trait Http2StreamHandling[T] { self: GraphStageLogic with LogHelp
     updateState(e.streamId, _.handle(e))
 
   /** Called by Http2ServerDemux when a stream comes in from the user-handler */
-  def handleOutgoingCreated(stream: Http2SubStream[Any]): Unit = {
+  def handleOutgoingCreated(stream: Http2SubStream): Unit = {
     stream.initialHeaders.priorityInfo.foreach(multiplexer.updatePriority)
     if (streamFor(stream.streamId) != Closed) {
       multiplexer.pushControlFrame(stream.initialHeaders)
@@ -560,7 +562,7 @@ private[http2] trait Http2StreamHandling[T] { self: GraphStageLogic with LogHelp
     def isDone: Boolean
   }
   object OutStream {
-    def apply(sub: Http2SubStream[Any]): OutStream = {
+    def apply(sub: Http2SubStream): OutStream = {
       val subIn = new SubSinkInlet[Any](s"substream-in-${sub.streamId}")
       val info = new OutStreamImpl(sub.streamId, None, multiplexer.currentInitialWindow)
       info.registerIncomingData(subIn)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -27,7 +27,7 @@ import scala.collection.immutable.VectorBuilder
 private[http2] object RequestParsing {
 
   @silent("use remote-address-attribute instead")
-  def parseRequest(httpHeaderParser: HttpHeaderParser, serverSettings: ServerSettings, attributes: Attributes): Http2SubStream[ByteString] => HttpRequest = {
+  def parseRequest(httpHeaderParser: HttpHeaderParser, serverSettings: ServerSettings, attributes: Attributes): Http2SubStream => HttpRequest = {
     val remoteAddressHeader: Option[`Remote-Address`] =
       if (serverSettings.remoteAddressHeader) {
         attributes.get[HttpAttributes.RemoteAddress].map(remote => model.headers.`Remote-Address`(RemoteAddress(remote.address)))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -13,7 +13,6 @@ import akka.http.scaladsl.settings.ServerSettings
 import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
 import FrameEvent.ParsedHeadersFrame
-import akka.util.ByteString
 
 private[http2] object ResponseRendering {
 
@@ -31,7 +30,7 @@ private[http2] object ResponseRendering {
     cachedDateHeader._2
   }
 
-  def renderResponse(settings: ServerSettings, log: LoggingAdapter): HttpResponse => Http2SubStream[Any] = {
+  def renderResponse(settings: ServerSettings, log: LoggingAdapter): HttpResponse => Http2SubStream = {
     def failBecauseOfMissingAttribute: Nothing =
       // attribute is missing, shutting down because we will most likely otherwise miss a response and leak a substream
       // TODO: optionally a less drastic measure would be only resetting all the active substreams
@@ -62,7 +61,7 @@ private[http2] object ResponseRendering {
     entity.contentLengthOption.foreach(headerPairs += "content-length" -> _.toString)
   }
 
-  private[http2] def substreamFor(entity: HttpEntity, headers: ParsedHeadersFrame): Http2SubStream[Any] = entity match {
+  private[http2] def substreamFor(entity: HttpEntity, headers: ParsedHeadersFrame): Http2SubStream = entity match {
     case HttpEntity.Chunked(_, chunks) =>
       ChunkedHttp2SubStream(headers, chunks, Map.empty)
     case _ =>

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/RequestRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/RequestRendering.scala
@@ -11,13 +11,12 @@ import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.http2.FrameEvent.ParsedHeadersFrame
 import akka.http.scaladsl.model.{ HttpRequest, RequestResponseAssociation }
-import akka.util.ByteString
 
 import scala.collection.immutable.VectorBuilder
 
 @InternalApi
 private[http2] object RequestRendering {
-  def createRenderer(log: LoggingAdapter): HttpRequest => Http2SubStream[Any] = {
+  def createRenderer(log: LoggingAdapter): HttpRequest => Http2SubStream = {
     val streamId = new AtomicInteger(1)
 
     { request =>

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -15,7 +15,7 @@ import scala.collection.immutable.VectorBuilder
 
 @InternalApi
 private[http2] object ResponseParsing {
-  def parseResponse(httpHeaderParser: HttpHeaderParser): ChunkedHttp2SubStream => HttpResponse = { subStream =>
+  def parseResponse(httpHeaderParser: HttpHeaderParser): Http2SubStream => HttpResponse = { subStream =>
     @tailrec
     def rec(
       remainingHeaders:  Seq[(String, String)],

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -37,7 +37,7 @@ class RequestParsingSpec extends AkkaSpec() with Inside with Inspectors {
         data = data
       )
       // Create the parsing function
-      val parseRequest: Http2SubStream[ByteString] => HttpRequest = {
+      val parseRequest: Http2SubStream => HttpRequest = {
         val (serverSettings, parserSettings) = {
           val ss = ServerSettings(system)
           val ps = ss.parserSettings.withUriParsingMode(uriParsingMode)


### PR DESCRIPTION
I removed a bit of the static type information to keeps types simpler where possible and used type members where the type is only interesting internally.